### PR TITLE
Update PDS4_PARTICLE_IngestLDD.xml to add "Energy Flux" as permissible value for particle_parameter_type

### DIFF
--- a/src/PDS4_PARTICLE_IngestLDD.xml
+++ b/src/PDS4_PARTICLE_IngestLDD.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model
-    href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1F00.sch"
+    href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1G00.sch"
     schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
 <!-- PDS4 Local Data Dictionary Ingest File -->
@@ -10,10 +10,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="
         http://pds.nasa.gov/pds4/pds/v1 
-        http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1F00.xsd ">
+        http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1G00.xsd ">
 
 	<name>Particle</name>
-	<ldd_version_id>2.0.0.0</ldd_version_id>
+	<ldd_version_id>2.0.1.0</ldd_version_id>
 	<dictionary_type>Discipline</dictionary_type>
 	<full_name>Joseph Mafi</full_name>
 	<steward_id>ppi</steward_id>
@@ -34,6 +34,11 @@
 		2.0.0.0 (J. Mafi, 2021-02-24):
 		   - Removed classes related to multidimensional data objects.
 		   - Added particle data parameter description attributes and classes.
+		   
+		2.0.1.0 (J. Mafi, 2021-06-24):
+		   - Updated to IM V.1.16.0.0
+		   - Added permissible value "Energy Flux" to 
+		     Particle_Observation/Particle_Parameter/particle_measurement_type
 	</comment>
 	<last_modification_date_time>2015-06-12T12:00:00Z</last_modification_date_time>
 
@@ -159,6 +164,10 @@
 			<DD_Permissible_Value>
 				<value>Pulse Height Analysis</value>
 				<value_meaning>Particle energy spectra over a specified time interval</value_meaning>
+			</DD_Permissible_Value>
+			<DD_Permissible_Value>
+				<value>Energy Flux</value>
+				<value_meaning>Particle energy per unit area per time. This value should be used for differential and integral energy flux as well.</value_meaning>
 			</DD_Permissible_Value>
 		</DD_Value_Domain>
 	</DD_Attribute>


### PR DESCRIPTION
## Summary
The value "Energy Flux" and corresponding value_meaning were added as permissible values for the parameter:
   Particle_Observation.Particle_Parameter.particle_parameter_type

The referenced IM version was updated to 1.16.0.0 (1G00) as well.

## Test Data and/or Report

## Related Issues

